### PR TITLE
Moves the bancheck in front of the feedback channel

### DIFF
--- a/models/Discord/Routers/DiscordRouterGuildMemberAdd.js
+++ b/models/Discord/Routers/DiscordRouterGuildMemberAdd.js
@@ -11,9 +11,9 @@ class DiscordRouterGuildMemberAdd extends DiscordRouter {
       var feedbackChannel = this.subsystem.getFeedbackChannel(member.guild);
       var date = new Date();
       var response = "`[" + date.getFullYear() + ":" + date.getMonth() + ":" + date.getDate() + " " + date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds() + "]` ";
-
-      feedbackChannel.send(response + "**" + member.user.username + "#" + member.user.discriminator + "** joined the server.");
+      
       this.subsystem.banManager.check(member);
+      feedbackChannel.send(response + "**" + member.user.username + "#" + member.user.discriminator + "** joined the server.");
     });
   }
 


### PR DESCRIPTION
why: In my test run of this, the fucking member.user.username crashed the bot, and rather than fix that i'd rather just do this :^)