### PR TITLE
makes Discord commands case insensitive

### DIFF
--- a/models/Subsystems/SubsystemDiscord.js
+++ b/models/Subsystems/SubsystemDiscord.js
@@ -156,7 +156,7 @@ class SubsystemDiscord extends Subsystem {
 
   getCommand(commandName) {
     for (var command of this.commands) {
-      if (command.name === commandName) {
+      if (command.name.toUpperCase() === commandName.toUpperCase()) {
         return command;
       }
     }


### PR DESCRIPTION
Per #admin-botspam
![JL2Aj1p](https://user-images.githubusercontent.com/18408197/63632741-1c671100-c60a-11e9-8248-e299ccf0a2eb.png)
