### PR TITLE
Adds the ability for staff to ban and warn people from staff public

### DIFF
--- a/config/discord.json
+++ b/config/discord.json
@@ -6,7 +6,10 @@
   "discord_guild": "134720091576205312",
   "discord_restricted_channels": ["134722015503319040", "201054477460045824", "162924271948005376", "188691067405598721"],
   "discord_subscriber_role": "1",
-  "discord_loreban_role": 716784185192480798,
+  "discord_loreban_role": "716784185192480798",
+  "discord_firstwarning_role": "514066643119505408",
+  "discord_secondwarning_role": "514066798216347662",
+  "discord_staffpublicban_role": "290926097028218884",
   "discord_tempban_interval": 15000,
   "asay_webhook_url": "https://discordapp.com/api/webhooks/eW91IGFyZSBhIGh1Z2UgbmVyZCBpZiB5b3UgYXJlIHJlYWRpbmcgdGhpcw==",
   "git_update": true

--- a/data/discord.json
+++ b/data/discord.json
@@ -5,10 +5,10 @@
       "permissions": []
     },
     "council": {
-      "inherits": "lead developer",
+      "inherits": "headcoder",
       "permissions": []
     },
-    "lead developer": {
+    "headcoder": {
       "inherits": "maintainer",
       "permissions": ["addao"]
     },
@@ -22,7 +22,7 @@
     },
     "retmin": {
       "inherits": "mentor",
-      "permissions": ["tempban", "ban", "unban", "kick", "reboot", "ticket", "whitelist", "kickself", "toggleooc", "note"]
+      "permissions": ["tempban", "ban", "unban", "kick", "reboot", "ticket", "whitelist", "kickself", "toggleooc", "note", "staffban"]
     },
     "mentor": {
       "inherits": false,

--- a/models/Discord/Commands/DiscordCommandStaffban.js
+++ b/models/Discord/Commands/DiscordCommandStaffban.js
@@ -1,0 +1,37 @@
+const DiscordCommand = require('../DiscordCommand.js');	
+
+class DiscordCommandStaffban extends DiscordCommand {	
+
+    constructor(subsystem) {	
+        super("staffban", "Ban someone from the staff public channel.", 'staffban', subsystem);	
+    }	
+
+    onRun(message, permissions, args) {	
+        let config = this.subsystem.manager.getSubsystem("Config").config;	
+        let member = message.mentions.members.first();
+        
+        if(member == undefined) {
+          message.reply("I could not find that user, Make sure you use the mention format of @Username");
+          return;
+        }
+
+        if (member.roles.has(config.discord_secondwarning_role)) {	
+            member.addRole(config.discord_staffpublicban_role);	
+            var response = "User was banned from staff public."	
+        }	
+        else {
+            if (member.roles.has(config.discord_firstwarning_role)) {	
+                member.addRole(config.discord_secondwarning_role);	
+                var response = "User was given the second warning role."
+        }
+        else {
+            member.addRole(config.discord_firstwarning_role);	
+            var response = "User was given the first warning role."	
+        }
+		
+        message.channel.send(response);	
+    }	
+
+}	
+
+module.exports = DiscordCommandStaffban;


### PR DESCRIPTION
How it works:

!staffban [@username]

If someone doesn't have a warning role, they get 1st warning role.
If someone has 1st warning role, they get 2nd warning role.
If someone has 2nd warning role, they get staff public ban role.

Additionally this PR:
fixes permissions that referenced lead developer, should fix things.
adds quotation marks around loreban role in config, something that I neglected to do.