### PR TITLE
Fixes a typo in the !mentor command, bringing its name to what it was supposed to be "!randombullshit"

### DIFF
--- a/models/Discord/Commands/DiscordCommandMentor.js
+++ b/models/Discord/Commands/DiscordCommandMentor.js
@@ -3,7 +3,7 @@ const DiscordCommand = require('../DiscordCommand.js');
 class DiscordCommandMentor extends DiscordCommand {
 
   constructor(subsystem) {
-    super("mentor", "Mentor department of yogstation", undefined, subsystem, true);
+    super("randombullshit", "Random bullshit on yogstation", undefined, subsystem, true);
   }
   		
   onRun(message, permissions, args) {


### PR DESCRIPTION
Ive noticed it was accidentally called !mentor instead of the intended !randombullshit