### PR TITLE
Adds !mynotes and !dnotes

### DIFF
--- a/models/Discord/Commands/DiscordCommandDNotes.js
+++ b/models/Discord/Commands/DiscordCommandDNotes.js
@@ -59,7 +59,7 @@ class DiscordCommandDNotes extends DiscordCommand {
             message.reply("Player has no notes.");
           }
           else {
-            var msg = "Notes for " + userID + "\n";
+            var msg = "Notes for " + userID + "/" + ckey + "\n";
             var shownNotes = [];
             for(var i = 0; i < results.length; i++){
               var result = results[i]

--- a/models/Discord/Commands/DiscordCommandMyNotes.js
+++ b/models/Discord/Commands/DiscordCommandMyNotes.js
@@ -1,0 +1,91 @@
+const DiscordCommand = require('../DiscordCommand.js');
+
+
+class DiscordCommandMyNotes extends DiscordCommand {
+
+  constructor(subsystem) {
+    super("mynotes", "Checks your notes", null, subsystem);
+  }
+
+  onRun(message, permissions, args) {
+
+    var dbSubsystem = this.subsystem.manager.getSubsystem("Database");
+
+    dbSubsystem.pool.getConnection((err, connection) => {
+      if (err) {
+        connection.release();
+        message.reply("Error contacting database, try again later.");
+        return;
+      }
+      var userID = message.author.id
+      if(!userID) {
+        message.reply("Unknown Error while getting Discord ID!")
+        return;
+      }
+
+      connection.query("SELECT * FROM `erro_player` WHERE `discord_id` = ?", [userID], (error, results, fields) => {
+        if (error) {
+          message.reply("Error running select query, try again later." + error);
+          return;
+        }
+        if (results.length == 0) {
+          message.reply("No linked BYOND account found. Are you sure you have linked your Discord to your BYOND?");
+          return;
+        }
+        if (results.length > 1) {
+          message.reply("More than one BYOND account linked to this ID. This shouldn't happen!");
+          return;
+        }
+
+        var ckey = results[0].ckey
+
+        connection.query('SELECT * FROM `erro_messages` WHERE `targetckey` = ? AND `type`= "note" AND deleted = 0 AND (expire_timestamp > NOW() OR expire_timestamp IS NULL) AND `secret` = 0 ORDER BY `timestamp`', [ckey], (error, results, fields) => {
+          var guildMember = message.member;
+          if (error) {
+            message.reply("Error getting notes, try again later.");
+          }
+          message.reply("Success. Check your Direct Messages." + ckey);
+          if (results.length == 0) {
+            guildMember.sendMessage("You have no notes.");
+          }
+          else {
+            var msg = "Notes for " + ckey + "\n";
+            var shownNotes = [];
+            for(var i = 0; i < results.length; i++){
+              var result = results[i]
+              var newmsg = "```" + result.timestamp + "\t" + result.text
+              if(shownNotes.length) {
+                for(var j = 0; j < shownNotes.length; j++) {
+                  if(newmsg == shownNotes[j]) {
+                    newmsg = null;
+                    break;
+                  }
+                }
+              }
+              if(newmsg == null) {
+                continue;
+              }
+              shownNotes.push(newmsg);
+              newmsg += "```";
+              if(msg.length + newmsg.length > 2000) {
+                guildMember.user.sendMessage(msg);
+                msg = newmsg;
+              }
+              else {
+                msg += newmsg;
+              }
+            }
+            guildMember.user.sendMessage(msg);
+          }
+          connection.release();
+        });
+      })
+
+
+
+    });
+  }
+
+}
+
+module.exports = DiscordCommandMyNotes;

--- a/models/Subsystems/SubsystemDatabase.js
+++ b/models/Subsystems/SubsystemDatabase.js
@@ -22,6 +22,7 @@ class SubsystemDatabase extends Subsystem {
     this.pool = sql.createPool({
       connectionLimit: config.sql_connections,
       host: config.sql_host,
+      port: config.sql_port,
       user: config.sql_user,
       password: config.sql_password,
       database: config.sql_database


### PR DESCRIPTION
### The !mynotes command:
Arguments: None
DMs you all your NON-SECRET notes that haven't been deleted and haven't expired

### The !dnotes command:
Arguments: @user
Works like the !notes command, but instead of a ckey you ping someone and it displays their notes if they have linked their account to their BYOND. Admin only of course, shows secret notes. Shows who applied the note if it's used in those secret admin channels.



Also makes the config.sql_port be actually used .-.
