### PR TITLE
Cannonalize the key before saving it so that people with spaces in their names don't get fucked

### DIFF
--- a/models/Byond/Endpoints/EndpointVerify.js
+++ b/models/Byond/Endpoints/EndpointVerify.js
@@ -34,7 +34,7 @@ module.exports = class EndpointVerify extends APIEndpoint {
 
             return callback(error, undefined)
         }
-        if(identity.ckey.toLowerCase() !== data.ckey.toLowerCase()) {
+        if(identity.ckey !== data.ckey) {
             const error = {
                 status: 400,
                 response: {status: "err", message: `Verification code links to ckey ${identity.ckey.toLowerCase()}, expected ${data.ckey.toLowerCase()}`}

--- a/models/Discord/Commands/DiscordCommandVerify.js
+++ b/models/Discord/Commands/DiscordCommandVerify.js
@@ -18,7 +18,6 @@ class DiscordCommandVerify extends DiscordCommand {
 
     //Delete the old hash
     if(this.subsystem.verificationMapIDToHash.has(message.author.id)) {
-      message.channel.send("You already have been issued a verification code, your previous verification code is now invalid. A new one will be sent.")
       const hashtodelete = this.subsystem.verificationMapIDToHash.get(message.author.id);
       this.subsystem.verificationMapHashToIdentity.delete(hashtodelete)
       this.subsystem.verificationMapIDToHash.delete(message.author.id)
@@ -27,7 +26,7 @@ class DiscordCommandVerify extends DiscordCommand {
     //Technically isn't a hash but it looks like one so im going to keep calling it that
     var hash;
     while(!hash) {
-      const candidate = crypto.randomBytes(40).toString("hex");
+      const candidate = crypto.randomBytes(8).toString("hex");
       //This is silly, the chances of getting the same random value is near to nil but im paranoid ok
       if(!this.subsystem.verificationMapHashToIdentity.has(candidate)) {
         hash = candidate

--- a/models/Discord/Commands/DiscordCommandVerify.js
+++ b/models/Discord/Commands/DiscordCommandVerify.js
@@ -18,7 +18,7 @@ class DiscordCommandVerify extends DiscordCommand {
 
     //Delete the old hash
     if(this.subsystem.verificationMapIDToHash.has(message.author.id)) {
-      message.reply("You already have been issued a verification code, your previous verification code is now invalid. A new one will be sent.")
+      message.channel.send("You already have been issued a verification code, your previous verification code is now invalid. A new one will be sent.")
       const hashtodelete = this.subsystem.verificationMapIDToHash.get(message.author.id);
       this.subsystem.verificationMapHashToIdentity.delete(hashtodelete)
       this.subsystem.verificationMapIDToHash.delete(message.author.id)
@@ -35,7 +35,7 @@ class DiscordCommandVerify extends DiscordCommand {
     }
 
     const identity = {
-      ckey: args[0],
+      ckey: args[0].toLowerCase().replace(/[^a-z@\d]/g, ""),
       discordsnowflake: message.author.id
     };
     this.subsystem.verificationMapHashToIdentity.set(hash, identity);


### PR DESCRIPTION
Also removes the message about already having a verification code
Also makes the verification hash much shorter because 40 bytes is way too much and overkill, 8 bytes is more than we will ever use