### PR TITLE
YogsPermissions Change

### DIFF
--- a/data/discord.json
+++ b/data/discord.json
@@ -13,20 +13,20 @@
       "permissions": []
     },
     "senior admin": {
-      "inherits": "maintainer",
-      "permissions": ["addao"]
-    },
-    "maintainer": {
       "inherits": "staff",
-      "permissions": []
+      "permissions": ["addao"]
     },
     "staff": {
       "inherits": "retmin",
       "permissions": ["userverify"]
     },
     "retmin": {
+      "inherits": "maintainer",
+      "permissions": ["tempban", "ban", "unban", "kick", "ticket", "whitelist", "toggleooc", "note", "staffban"]
+    },
+    "maintainer": {
       "inherits": "mentor",
-      "permissions": ["tempban", "ban", "unban", "kick", "reboot", "ticket", "whitelist", "kickself", "toggleooc", "note", "staffban"]
+      "permissions": ["reboot", "kickself"]
     },
     "mentor": {
       "inherits": false,


### PR DESCRIPTION
Swaps some permissions around on discord.json, moving retmin to inherit from maintainer, staff to inherit from retmin, and maintainer to inherit from mentor. Admin-related permissions have been moved to retmin which inherits from maintainer with server-related permissions such as reboot.