### PR TITLE
Hopefully fixes Wikiban

### DIFF
--- a/data/discord.json
+++ b/data/discord.json
@@ -48,7 +48,7 @@
       "inherits": false,
       "permissions": ["loreban"]
     },
-    "Wiki Team": {
+    "Wiki Staff": {
       "inherits": false,
       "permissions": ["wikiban"]
     },


### PR DESCRIPTION
I'm pretty sure the wiki team role in the discord has two damn spaces