### PR TITLE
Prepending message by - makes yogbot not respond in #bug-reports

### DIFF
--- a/models/Discord/Channels/DiscordCommandBugReport.js
+++ b/models/Discord/Channels/DiscordCommandBugReport.js
@@ -12,7 +12,11 @@ class DiscordCommandBugReport extends DiscordChannel {
     var config = this.subsystem.manager.getSubsystem("Config").config;
     //Split by line breaks, only splits on purposeful shift+enter in Discord.
     let lines = message.content.split("\n")
-
+    
+    if(lines[0][0] === "-") {
+      return 
+    }
+    
     //Title of issue
     let title = "";
     //Text body of issue


### PR DESCRIPTION
In case we have to yell at someone and we don't want to be yelled at by the bot